### PR TITLE
feat(deploy/w3c): upload tar instead of using manifest

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,8 +23,6 @@ inputs:
     description: GitHub Personal access token. Required only if the default GitHub actions token doesn't have enough permissions.
   W3C_ECHIDNA_TOKEN:
     description: Echidna token
-  W3C_MANIFEST_URL:
-    description: Echidna manifest URL
   W3C_WG_DECISION_URL:
     description: A URL to the working group decision to use auto-publish (usually from a w3c mailing list).
   W3C_NOTIFICATIONS_CC:

--- a/action.yml
+++ b/action.yml
@@ -102,3 +102,4 @@ runs:
       shell: bash
       env:
         INPUTS_DEPLOY: ${{ toJson(fromJson(steps.prepare.outputs.all).deploy.w3c) }}
+        OUTPUT_DIR: ${{ fromJson(steps.generate-html.outputs.output).dir }}

--- a/deploy-w3c-echidna.js
+++ b/deploy-w3c-echidna.js
@@ -67,6 +67,7 @@ async function publish(outputDir, input) {
 		output: "stream",
 		cwd: outputDir,
 	});
+	await sh("mv Overview.html index.html", { cwd: outputDir });
 
 	let command = `curl '${API_URL}'`;
 	command += ` -F "dry-run=true"`;

--- a/deploy-w3c-echidna.js
+++ b/deploy-w3c-echidna.js
@@ -62,6 +62,7 @@ async function main(outputDir, inputs) {
 async function publish(outputDir, input) {
 	const { wgDecisionURL: decision, token, cc } = input;
 	const tarFileName = "/tmp/echidna.tar";
+	await sh("mv index.html Overview.html", { cwd: outputDir });
 	await sh(`tar cvf ${tarFileName} *`, {
 		output: "stream",
 		cwd: outputDir,
@@ -70,7 +71,6 @@ async function publish(outputDir, input) {
 	let command = `curl '${API_URL}'`;
 	command += ` -F "dry-run=true"`;
 	command += ` -F "tar=@${tarFileName}"`;
-	command += ` -F "token=${token}"`;
 	command += ` -F "token=${token}"`;
 	command += ` -F "decision=${decision}"`;
 	if (cc) command += ` -F "cc=${cc}"`;

--- a/deploy-w3c-echidna.js
+++ b/deploy-w3c-echidna.js
@@ -75,7 +75,7 @@ async function publish(outputDir, input) {
 	command += ` -F "decision=${decision}"`;
 	if (cc) command += ` -F "cc=${cc}"`;
 
-	const id = await sh(command, "stream");
+	const id = await sh(command);
 	return id.trim();
 }
 

--- a/deploy-w3c-echidna.js
+++ b/deploy-w3c-echidna.js
@@ -70,7 +70,7 @@ async function publish(outputDir, input) {
 	await sh("mv Overview.html index.html", { cwd: outputDir });
 
 	let command = `curl '${API_URL}'`;
-	command += ` -F "dry-run=true"`;
+	// command += ` -F "dry-run=true"`;
 	command += ` -F "tar=@${tarFileName}"`;
 	command += ` -F "token=${token}"`;
 	command += ` -F "decision=${decision}"`;

--- a/deploy-w3c-echidna.js
+++ b/deploy-w3c-echidna.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { env, exit, pprint, request } = require("./utils.js");
+const { env, exit, pprint, request, sh } = require("./utils.js");
 
 const MAILING_LIST = `https://lists.w3.org/Archives/Public/public-tr-notifications/`;
 const API_URL = "https://labs.w3.org/echidna/api/request";
@@ -8,21 +8,22 @@ const API_URL = "https://labs.w3.org/echidna/api/request";
 if (module === require.main) {
 	/** @type {import("./prepare.js").W3CDeployOptions} */
 	const inputs = JSON.parse(env("INPUTS_DEPLOY"));
+	const outputDir = env("OUTPUT_DIR");
 	if (inputs === false) {
 		exit("Skipped.", 0);
 	}
-	main(inputs).catch(err => exit(err.message || "Failed", err.code));
+	main(outputDir, inputs).catch(err => exit(err.message || "Failed", err.code));
 }
 
 module.exports = main;
 /**
  * @typedef {Exclude<import("./prepare.js").W3CDeployOptions, false>} W3CDeployOptions
  * @param {W3CDeployOptions} inputs
+ * @param {string} outputDir
  */
-async function main(inputs) {
-	const { manifest, wgDecisionURL, token, cc } = inputs;
+async function main(outputDir, inputs) {
 	console.log(`📣 If it fails, check ${MAILING_LIST}`);
-	const id = await publish({ manifest, wgDecisionURL, token, cc });
+	const id = await publish(outputDir, inputs);
 
 	console.group("Getting publish status...");
 	const result = await getPublishStatus(id);
@@ -52,23 +53,30 @@ async function main(inputs) {
 
 /**
  * @param {object} input
- * @param {string} input.manifest Echidna manifest URL
  * @param {string} input.wgDecisionURL
  * @param {string} input.token
  * @param {string} [input.cc]
+ * @param {string} outputDir
  * @returns {Promise<string>}
  */
-async function publish(input) {
-	const { manifest: url, wgDecisionURL: decision, token, cc } = input;
-	const data = { url, decision, token, cc };
-	const body = new URLSearchParams(Object.entries(data)).toString();
-	return await request(new URL(API_URL), {
-		method: "POST",
-		body,
-		headers: {
-			"Content-Type": "application/x-www-form-urlencoded",
-		},
+async function publish(outputDir, input) {
+	const { wgDecisionURL: decision, token, cc } = input;
+	const tarFileName = "/tmp/echidna.tar";
+	await sh(`tar cvf ${tarFileName} *`, {
+		output: "stream",
+		cwd: outputDir,
 	});
+
+	let command = `curl '${API_URL}'`;
+	command += ` -F "dry-run=true"`;
+	command += ` -F "tar=@${tarFileName}"`;
+	command += ` -F "token=${token}"`;
+	command += ` -F "token=${token}"`;
+	command += ` -F "decision=${decision}"`;
+	if (cc) command += ` -F "cc=${cc}"`;
+
+	const id = await sh(command, "stream");
+	return id.trim();
 }
 
 /**

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -105,6 +105,5 @@ jobs:
         with:
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
           # Replace following with appropriate values. See options.md for details.
-          W3C_MANIFEST_URL: https://w3c.github.io/REPO/MANIFEST
           W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-group/2014JulSep/1234.html
 ```

--- a/docs/options.md
+++ b/docs/options.md
@@ -5,7 +5,7 @@
 - General: [`TOOLCHAIN`](#toolchain), [`SOURCE`](#source)
 - Validation: [`VALIDATE_LINKS`](#validate_links), [`VALIDATE_MARKUP`](#validate_markup)
 - GitHub Pages: [`GH_PAGES_BRANCH`](#gh_pages_branch), [`GH_PAGES_TOKEN`](#gh_pages_token)
-- W3C Publish\*: [`W3C_ECHIDNA_TOKEN`](#w3c_echidna_token), [`W3C_MANIFEST_URL`](#w3c_manifest_url), [`W3C_WG_DECISION_URL`](#w3c_wg_decision_url), [`W3C_NOTIFICATIONS_CC`](#w3c_notifications_cc)
+- W3C Publish\*: [`W3C_ECHIDNA_TOKEN`](#w3c_echidna_token), [`W3C_WG_DECISION_URL`](#w3c_wg_decision_url), [`W3C_NOTIFICATIONS_CC`](#w3c_notifications_cc)
 
 \*W3C Publish: Using Echidna. Presently only supported with ReSpec.
 
@@ -64,20 +64,6 @@ The automated publication workflow requires a [token](https://github.com/w3c/ech
 **Possible values:** A valid Echidna token.
 
 **Default:** None.
-
-## `W3C_MANIFEST_URL`
-
-URL to Echidna manifest file. An [Echidna manifest file](https://github.com/w3c/echidna/wiki/Preparing-your-document#manifest-file) needs live at the root of your repository. It must be accessible via GitHub pages.
-
-An example of a minimal Echidna manifest file (say, `<REPOSITORY_ROOT>/ECHIDNA`):
-
-```
-index.html?specStatus=WD&shortName=your-spec-shortname respec
-```
-
-**Possible values:** A publicly accessible URL to Echidna manifest.
-
-**Default:** `https://ORG.github.io/REPO/ECHIDNA`
 
 ## `W3C_WG_DECISION_URL`
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -5,9 +5,7 @@
 - General: [`TOOLCHAIN`](#toolchain), [`SOURCE`](#source)
 - Validation: [`VALIDATE_LINKS`](#validate_links), [`VALIDATE_MARKUP`](#validate_markup)
 - GitHub Pages: [`GH_PAGES_BRANCH`](#gh_pages_branch), [`GH_PAGES_TOKEN`](#gh_pages_token)
-- W3C Publish\*: [`W3C_ECHIDNA_TOKEN`](#w3c_echidna_token), [`W3C_WG_DECISION_URL`](#w3c_wg_decision_url), [`W3C_NOTIFICATIONS_CC`](#w3c_notifications_cc)
-
-\*W3C Publish: Using Echidna. Presently only supported with ReSpec.
+- W3C Publish: [`W3C_ECHIDNA_TOKEN`](#w3c_echidna_token), [`W3C_WG_DECISION_URL`](#w3c_wg_decision_url), [`W3C_NOTIFICATIONS_CC`](#w3c_notifications_cc)
 
 ## `TOOLCHAIN`
 

--- a/prepare.js
+++ b/prepare.js
@@ -194,7 +194,7 @@ function githubPagesDeployment(inputs, githubContext) {
  * @typedef {ThenArg<ReturnType<typeof w3cEchidnaDeployment>>} W3CDeployOptions
  */
 async function w3cEchidnaDeployment(inputs, githubContext) {
-	const { event_name: event, repository } = githubContext;
+	const { event_name: event } = githubContext;
 	if (!shouldTryDeploy(event)) {
 		return false;
 	}

--- a/prepare.js
+++ b/prepare.js
@@ -48,7 +48,6 @@ async function main(inputs, githubContext) {
  * @property {string} [inputs.GH_PAGES_BRANCH]
  * @property {string} [inputs.GH_PAGES_TOKEN]
  * @property {string} [inputs.W3C_ECHIDNA_TOKEN]
- * @property {string} [inputs.W3C_MANIFEST_URL]
  * @property {string} [inputs.W3C_WG_DECISION_URL]
  * @property {string} [inputs.W3C_NOTIFICATIONS_CC]
  *
@@ -209,20 +208,9 @@ async function w3cEchidnaDeployment(inputs, githubContext) {
 		return false;
 	}
 
-	let manifest = inputs.W3C_MANIFEST_URL;
-	if (!manifest) {
-		if (existsSync("ECHIDNA")) {
-			const [owner, name] = repository.split("/");
-			manifest = `https://${owner}.github.io/${name}/ECHIDNA`;
-		} else {
-			console.log(`🚧 Echidna manifest file was not found.`);
-			return false;
-		}
-	}
-
 	const cc = inputs.W3C_NOTIFICATIONS_CC;
 
-	return { manifest, wgDecisionURL, cc, token: token };
+	return { wgDecisionURL, cc, token: token };
 }
 
 /**


### PR DESCRIPTION
BREAKING CHANGE: `W3C_MANIFEST_URL` will no longer be supported.
- ~add option to configure `specStatus` and `shortName`~ This should be done at spec config level*.
- [x] remove `W3C_MANIFEST_URL` option from supported options

Closes https://github.com/w3c/spec-prod/issues/12
Closes https://github.com/w3c/spec-prod/issues/21

\* With ReSpec, something like following should be possible:
```js
var respecConfig = {
  specStatus: "WD",
}
if (isGitHubPages()) {
  respecConfig.specStatus = "ED";
}
```