### PR TITLE
feat(build): add BUILD_FAIL_ON config option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
     description: Possible values - 'respec', 'bikeshed'
   SOURCE:
     description: Source file path.
+  BUILD_FAIL_ON:
+    description: Exit behaviour on errors.
+    default: fatal
   VALIDATE_LINKS:
     description: Validate hyperlinks
     default: true

--- a/docs/options.md
+++ b/docs/options.md
@@ -2,7 +2,7 @@
 
 ## Table of Contents
 
-- General: [`TOOLCHAIN`](#toolchain), [`SOURCE`](#source)
+- Build: [`TOOLCHAIN`](#toolchain), [`SOURCE`](#source), [`BUILD_FAIL_ON`](#build_fail_on)
 - Validation: [`VALIDATE_LINKS`](#validate_links), [`VALIDATE_MARKUP`](#validate_markup)
 - GitHub Pages: [`GH_PAGES_BRANCH`](#gh_pages_branch), [`GH_PAGES_TOKEN`](#gh_pages_token)
 - W3C Publish: [`W3C_ECHIDNA_TOKEN`](#w3c_echidna_token), [`W3C_WG_DECISION_URL`](#w3c_wg_decision_url), [`W3C_NOTIFICATIONS_CC`](#w3c_notifications_cc)
@@ -22,6 +22,22 @@ Source file path.
 **Possible values:** Any valid POSIX file path relative to repository root.
 
 **Default:** None. Inferred from `TOOLCHAIN`: `index.html`/`index.bs` if exists.
+
+## `BUILD_FAIL_ON`
+
+Define exit behaviour on build errors or warnings.
+
+**Possible values:** `"nothing"`, `"fatal"`, `"link-error"`, `"warning"`, `"everything"`.
+
+| `BUILD_FAIL_ON` | Bikeshed               | ReSpec                 |
+| --------------- | ---------------------- | ---------------------- |
+| nothing         | `--die-on=nothing`     | Absent.                |
+| fatal           | `--die-on=fatal `      | `--haltonerror` (`-e`) |
+| link-error      | `--die-on=error `      | `--haltonerror` (`-e`) |
+| warning         | `--die-on=warning `    | `--haltonwarn` (`-w`)  |
+| everything      | `--die-on=everything ` | `-e -w`                |
+
+**Default:** `"fatal"`.
 
 ## `VALIDATE_LINKS`
 

--- a/src/build.js
+++ b/src/build.js
@@ -9,16 +9,20 @@ const { env, exit, setOutput, sh, ACTION_DIR } = require("./utils.js");
 // @ts-expect-error
 if (module === require.main) {
 	/** @type {BuildInput} */
-	const { toolchain, source } = JSON.parse(env("INPUTS_BUILD"));
-	main(toolchain, source).catch(err => exit(err.message || "Failed", err.code));
+	const { toolchain, source, flags } = JSON.parse(env("INPUTS_BUILD"));
+	main(toolchain, source, flags).catch(err =>
+		exit(err.message || "Failed", err.code),
+	);
 }
 
 module.exports = main;
 /**
  * @param {BuildInput["toolchain"]} toolchain
  * @param {BuildInput["source"]} source
+ * @param {BuildInput["flags"]} additionalFlags
  */
-async function main(toolchain, source) {
+async function main(toolchain, source, additionalFlags) {
+	const flags = additionalFlags.join(" ");
 	// Please do not rely on this value. If you would like this to be available as
 	// an action output, file an issue.
 	const outputFile = source + ".built.html";
@@ -27,13 +31,13 @@ async function main(toolchain, source) {
 		case "respec":
 			console.log(`Converting ReSpec document '${source}' to HTML...`);
 			await sh(
-				`respec -s "${source}" -o "${outputFile}" --verbose --timeout 20`,
+				`respec -s "${source}" -o "${outputFile}" --verbose --timeout 20 ${flags}`,
 				"stream",
 			);
 			break;
 		case "bikeshed":
 			console.log(`Converting Bikeshed document '${source}' to HTML...`);
-			await sh(`bikeshed spec "${source}" "${outputFile}"`, "stream");
+			await sh(`bikeshed spec "${source}" "${outputFile}" ${flags}`, "stream");
 			break;
 		default:
 			throw new Error(`Unknown "TOOLCHAIN": "${toolchain}"`);

--- a/src/prepare.js
+++ b/src/prepare.js
@@ -154,7 +154,7 @@ function getFailOnFlags(toolchain, failOn) {
 	if (failOn && !FAIL_ON_OPTIONS.includes(failOn)) {
 		exit(
 			`BUILD_FAIL_ON must be one of [${FAIL_ON_OPTIONS.join(", ")}]. ` +
-				`Found ${failOn}.`,
+				`Found "${failOn}".`,
 		);
 	}
 	switch (toolchain) {

--- a/src/prepare.js
+++ b/src/prepare.js
@@ -9,6 +9,14 @@ const {
 	yesOrNo,
 } = require("./utils.js");
 
+const FAIL_ON_OPTIONS = [
+	"nothing",
+	"fatal",
+	"link-error",
+	"warning",
+	"everything",
+];
+
 // @ts-expect-error
 if (module === require.main) {
 	/** @type {Inputs} */
@@ -43,6 +51,7 @@ async function main(inputs, githubContext) {
  * @typedef {object} Inputs
  * @property {"respec" | "bikeshed" | string} [inputs.TOOLCHAIN]
  * @property {string} [inputs.SOURCE]
+ * @property {string} [inputs.BUILD_FAIL_ON]
  * @property {string} [inputs.VALIDATE_LINKS]
  * @property {string} [inputs.VALIDATE_MARKUP]
  * @property {string} [inputs.GH_PAGES_BRANCH]
@@ -85,6 +94,7 @@ async function processInputs(inputs, githubContext) {
 function buildOptions(inputs) {
 	let toolchain = inputs.TOOLCHAIN;
 	let source = inputs.SOURCE;
+	let failOn = inputs.BUILD_FAIL_ON;
 
 	if (toolchain) {
 		switch (toolchain) {
@@ -130,7 +140,40 @@ function buildOptions(inputs) {
 		}
 	}
 
-	return { toolchain, source };
+	const flags = [];
+	flags.push(...getFailOnFlags(toolchain, failOn));
+
+	return { toolchain, source, flags };
+}
+
+/**
+ * @param {"respec" | "bikeshed" | string} toolchain
+ * @param {string} failOn
+ */
+function getFailOnFlags(toolchain, failOn) {
+	if (failOn && !FAIL_ON_OPTIONS.includes(failOn)) {
+		exit(
+			`BUILD_FAIL_ON must be one of [${FAIL_ON_OPTIONS.join(", ")}]. ` +
+				`Found ${failOn}.`,
+		);
+	}
+	switch (toolchain) {
+		case "respec": {
+			switch (failOn) {
+				case "fatal":
+				case "link-error":
+					return ["-e"];
+				case "warning":
+					return ["-w"];
+				case "everything":
+					return ["-e", "-w"];
+			}
+		}
+		case "bikeshed": {
+			return [`--die-on=${failOn}`];
+		}
+	}
+	return [];
 }
 
 /**


### PR DESCRIPTION
Allows configuring on what kinds of errors/warnings build should fail. By default, fails on fatal errors.
Closes https://github.com/w3c/spec-prod/issues/19
Closes https://github.com/w3c/spec-prod/issues/20