### PR TITLE
feat: override build config for W3C and gh-pages builds

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,8 @@ inputs:
     description: Echidna token
   W3C_WG_DECISION_URL:
     description: A URL to the working group decision to use auto-publish (usually from a w3c mailing list).
+  W3C_BUILD_OVERRIDE:
+    description: Override Bikeshed's metadata or ReSpec's respecConfig for W3C deploy and validations.
   W3C_NOTIFICATIONS_CC:
     description: Comma separated list of email addresses to CC
 

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,8 @@ inputs:
     default: true
   GH_PAGES_BRANCH:
     description: Provide a branch name to deploy to GitHub pages.
+  GH_PAGES_BUILD_OVERRIDE:
+    description: Override Bikeshed's metadata or ReSpec's respecConfig for GitHub Pages deployment.
   GH_PAGES_TOKEN:
     description: GitHub Personal access token. Required only if the default GitHub actions token doesn't have enough permissions.
   W3C_ECHIDNA_TOKEN:
@@ -29,7 +31,7 @@ inputs:
   W3C_WG_DECISION_URL:
     description: A URL to the working group decision to use auto-publish (usually from a w3c mailing list).
   W3C_BUILD_OVERRIDE:
-    description: Override Bikeshed's metadata or ReSpec's respecConfig for W3C deploy and validations.
+    description: Override Bikeshed's metadata or ReSpec's respecConfig for W3C deployment and validations.
   W3C_NOTIFICATIONS_CC:
     description: Comma separated list of email addresses to CC
 
@@ -75,7 +77,7 @@ runs:
       shell: bash
       env:
         INPUTS_VALIDATE_LINKS: ${{ fromJson(steps.prepare.outputs.all).validate.links }}
-        OUTPUT_DIR: ${{ fromJson(steps.generate-html.outputs.output).dir }}
+        OUTPUT_DIR: ${{ fromJson(steps.generate-html.outputs.w3c).dir }}
 
     - name: Validate markup
       run: |
@@ -85,7 +87,7 @@ runs:
       shell: bash
       env:
         INPUTS_VALIDATE_MARKUP: ${{ fromJson(steps.prepare.outputs.all).validate.markup }}
-        OUTPUT_DIR: ${{ fromJson(steps.generate-html.outputs.output).dir }}
+        OUTPUT_DIR: ${{ fromJson(steps.generate-html.outputs.w3c).dir }}
 
     - name: Deploy to GitHub pages
       run: |
@@ -95,7 +97,7 @@ runs:
       shell: bash
       env:
         INPUTS_DEPLOY: ${{ toJson(fromJson(steps.prepare.outputs.all).deploy.ghPages) }}
-        OUTPUT_DIR: ${{ fromJson(steps.generate-html.outputs.output).dir }}
+        OUTPUT_DIR: ${{ fromJson(steps.generate-html.outputs.gh).dir }}
 
     - name: Deploy to W3C
       run: |
@@ -105,4 +107,4 @@ runs:
       shell: bash
       env:
         INPUTS_DEPLOY: ${{ toJson(fromJson(steps.prepare.outputs.all).deploy.w3c) }}
-        OUTPUT_DIR: ${{ fromJson(steps.generate-html.outputs.output).dir }}
+        OUTPUT_DIR: ${{ fromJson(steps.generate-html.outputs.w3c).dir }}

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -105,3 +105,33 @@ jobs:
           # Replace following with appropriate value. See options.md for details.
           W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-group/2014JulSep/1234.html
 ```
+
+### Use different `respecConfig` when deploying to W3C
+
+```yaml
+# Example: Override respecConfig for W3C deployment and validators.
+name: CI
+on:
+  pull_request: {}
+  push:
+    branches: [main]
+jobs:
+  main:
+    name: Build, Validate and Deploy
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: w3c/spec-prod@v2
+        with:
+          TOOLCHAIN: respec
+          W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
+          W3C_WG_DECISION_URL: https://WG_DECISION_URL_FOR_MY_SPEC.com
+          # Publish to w3.org/TR as a Working Draft (WD) under a different shortName.
+          W3C_BUILD_OVERRIDE: |
+            specStatus: WD
+            previousMaturity: LC
+            previousPublishDate: 2014-05-01
+            shortName: my-custom-shortname
+```
+
+See [`W3C_BUILD_OVERRIDE`](options.md#w3c_build_override) and [`GH_PAGES_BUILD_OVERRIDE`](options.md#gh_pages_build_override) for details.

--- a/docs/options.md
+++ b/docs/options.md
@@ -53,9 +53,10 @@ Override Bikeshed metadata or ReSpec config for the GitHub Pages deployment.
     GH_PAGES_BUILD_OVERRIDE: |
       status: w3c/WD
       TR: https://www.w3.org/TR/my-cool-spec/
-    # Note: the content in GH_PAGES_BUILD_OVERRIDE might look like YAML key-value pairs, but it's actually a string.
+    # Warning: The content in GH_PAGES_BUILD_OVERRIDE might look like YAML key-value pairs, but it's actually a string.
     # GitHub Actions allow only strings as input.
-    # Info: above is same as running Bikeshed CLI like:
+    #
+    # Info: Above is same as running Bikeshed CLI like:
     # bikeshed spec INPUT OUTPUT --md-status="w3c/WD" --md-TR="https://www.w3.org/TR/my-cool-spec/"
 ```
 
@@ -79,8 +80,9 @@ Override Bikeshed metadata or ReSpec config for the W3C Deployment and validator
       shortName: my-custom-shortname
       previousMaturity: LC
       previousPublishDate: 2014-05-01
-    # Note: The content in W3C_BUILD_OVERRIDE might look like YAML key-value pairs, but it's actually a string.
+    # Warning: The content in W3C_BUILD_OVERRIDE might look like YAML key-value pairs, but it's actually a string.
     # GitHub Actions allow only strings as input.
+    #
     # Info: Above is equivalent to running ReSpec CLI like:
     # respec -s index.html?specStatus=WD&shortName=my-custom-shortname… -o OUTPUT
 ```

--- a/docs/options.md
+++ b/docs/options.md
@@ -2,7 +2,7 @@
 
 ## Table of Contents
 
-- Build: [`TOOLCHAIN`](#toolchain), [`SOURCE`](#source), [`BUILD_FAIL_ON`](#build_fail_on)
+- Build: [`TOOLCHAIN`](#toolchain), [`SOURCE`](#source), [`BUILD_FAIL_ON`](#build_fail_on), [`GH_PAGES_BUILD_OVERRIDE`](#gh_pages_build_override), [`W3C_BUILD_OVERRIDE`](#w3c_build_override)
 - Validation: [`VALIDATE_LINKS`](#validate_links), [`VALIDATE_MARKUP`](#validate_markup)
 - GitHub Pages: [`GH_PAGES_BRANCH`](#gh_pages_branch), [`GH_PAGES_TOKEN`](#gh_pages_token)
 - W3C Publish: [`W3C_ECHIDNA_TOKEN`](#w3c_echidna_token), [`W3C_WG_DECISION_URL`](#w3c_wg_decision_url), [`W3C_NOTIFICATIONS_CC`](#w3c_notifications_cc)
@@ -38,6 +38,52 @@ Define exit behaviour on build errors or warnings.
 | everything      | `--die-on=everything ` | `-e -w`                |
 
 **Default:** `"fatal"`.
+
+## `GH_PAGES_BUILD_OVERRIDE`
+
+Override Bikeshed metadata or ReSpec config for the GitHub Pages deployment.
+
+**Possible values:** A string or [YAML Literal Block Scalar](https://stackoverflow.com/a/15365296) (multiline string) representing the override config/metadata as key-value pairs. That's mouthful, lets clarify using an example:
+
+```yaml
+# Example: Override Bikeshed metadata for GitHub Pages deployment
+- uses: w3c/spec-prod@v2
+  with:
+    TOOLCHAIN: bikeshed
+    GH_PAGES_BUILD_OVERRIDE: |
+      status: w3c/WD
+      TR: https://www.w3.org/TR/my-cool-spec/
+    # Note: the content in GH_PAGES_BUILD_OVERRIDE might look like YAML key-value pairs, but it's actually a string.
+    # GitHub Actions allow only strings as input.
+    # Info: above is same as running Bikeshed CLI like:
+    # bikeshed spec INPUT OUTPUT --md-status="w3c/WD" --md-TR="https://www.w3.org/TR/my-cool-spec/"
+```
+
+**Default:** None.
+
+## `W3C_BUILD_OVERRIDE`
+
+Override Bikeshed metadata or ReSpec config for the W3C Deployment and validators.
+
+**Possible values:** Same as [`GH_PAGES_BUILD_OVERRIDE`](#gh_pages_build_override).
+
+**Default:** None.
+
+```yaml
+# Example: Override respecConfig for W3C deployment and validators.
+- uses: w3c/spec-prod@v2
+  with:
+    TOOLCHAIN: respec
+    W3C_BUILD_OVERRIDE: |
+      specStatus: WD
+      shortName: my-custom-shortname
+      previousMaturity: LC
+      previousPublishDate: 2014-05-01
+    # Note: The content in W3C_BUILD_OVERRIDE might look like YAML key-value pairs, but it's actually a string.
+    # GitHub Actions allow only strings as input.
+    # Info: Above is equivalent to running ReSpec CLI like:
+    # respec -s index.html?specStatus=WD&shortName=my-custom-shortname… -o OUTPUT
+```
 
 ## `VALIDATE_LINKS`
 

--- a/src/build.js
+++ b/src/build.js
@@ -55,14 +55,12 @@ async function build(toolchain, source, destDir, additionalFlags, conf) {
 	const outputFile = source + ".built.html";
 
 	switch (toolchain) {
-		case "respec": {
+		case "respec":
 			await buildReSpec(source, outputFile, additionalFlags, conf);
 			break;
-		}
-		case "bikeshed": {
+		case "bikeshed":
 			await buildBikeshed(source, outputFile, additionalFlags, conf);
 			break;
-		}
 		default:
 			throw new Error(`Unknown "TOOLCHAIN": "${toolchain}"`);
 	}

--- a/src/build.js
+++ b/src/build.js
@@ -54,6 +54,7 @@ async function main(toolchain, source, flags, configOverride) {
 async function build(toolchain, source, destDir, additionalFlags, conf) {
 	const outputFile = source + ".built.html";
 
+	console.group(`[INFO] Build ${toolchain} document "${source}"…`);
 	switch (toolchain) {
 		case "respec":
 			await buildReSpec(source, outputFile, additionalFlags, conf);
@@ -65,7 +66,9 @@ async function build(toolchain, source, destDir, additionalFlags, conf) {
 			throw new Error(`Unknown "TOOLCHAIN": "${toolchain}"`);
 	}
 
-	return await copyRelevantAssets(outputFile, destDir);
+	const res = await copyRelevantAssets(outputFile, destDir);
+	console.groupEnd();
+	return res;
 }
 
 /**
@@ -75,7 +78,6 @@ async function build(toolchain, source, destDir, additionalFlags, conf) {
  * @param {BuildInput["configOverride"]["gh" | "w3c"]} conf
  */
 async function buildReSpec(source, outputFile, additionalFlags, conf) {
-	console.log(`Converting ReSpec document '${source}' to HTML...`);
 	const flags = additionalFlags.join(" ");
 	const params = new URLSearchParams(conf).toString();
 	if (params) source += `?${params}`;
@@ -95,7 +97,6 @@ async function buildReSpec(source, outputFile, additionalFlags, conf) {
  * @param {BuildInput["configOverride"]["gh" | "w3c"]} conf
  */
 async function buildBikeshed(source, outputFile, additionalFlags, conf) {
-	console.log(`Converting Bikeshed document '${source}' to HTML...`);
 	const metadataFlags = Object.entries(conf || {}).map(
 		([key, val]) => `--md-${key.replace(/\s+/g, "-")}="${val}"`,
 	);

--- a/src/build.js
+++ b/src/build.js
@@ -78,9 +78,9 @@ async function buildReSpec(source, outputFile, additionalFlags, conf) {
 	console.log(`Converting ReSpec document '${source}' to HTML...`);
 	const flags = additionalFlags.join(" ");
 	const params = new URLSearchParams(conf).toString();
-	const src = `${source}${params ? `?${params}` : ""}`;
+	source = `${source}${params ? `?${params}` : ""}`;
 	await sh(
-		`respec -s "${src}" -o "${outputFile}" --verbose --timeout 20 ${flags}`,
+		`respec -s "${source}" -o "${outputFile}" --verbose --timeout 20 ${flags}`,
 		{
 			output: "stream",
 			env: { PUPPETEER_EXECUTABLE_PATH: "/usr/bin/google-chrome" },

--- a/src/build.js
+++ b/src/build.js
@@ -78,7 +78,7 @@ async function buildReSpec(source, outputFile, additionalFlags, conf) {
 	console.log(`Converting ReSpec document '${source}' to HTML...`);
 	const flags = additionalFlags.join(" ");
 	const params = new URLSearchParams(conf).toString();
-	source = `${source}${params ? `?${params}` : ""}`;
+	if (params) source += `?${params}`;
 	await sh(
 		`respec -s "${source}" -o "${outputFile}" --verbose --timeout 20 ${flags}`,
 		{

--- a/src/prepare.js
+++ b/src/prepare.js
@@ -162,7 +162,9 @@ function getConfigOverride(confStr) {
 	/** @type {Record<string, string>} */
 	const config = {};
 	for (const line of confStr.trim().split("\n")) {
-		const [key, value] = line.split(":", 2).map(s => s.trim());
+		const idx = line.indexOf(":");
+		const key = line.slice(0, idx).trim();
+		const value = line.slice(idx + 1).trim();
 		config[key] = value;
 	}
 	return config;

--- a/src/prepare.js
+++ b/src/prepare.js
@@ -56,7 +56,9 @@ async function main(inputs, githubContext) {
  * @property {string} [inputs.VALIDATE_MARKUP]
  * @property {string} [inputs.GH_PAGES_BRANCH]
  * @property {string} [inputs.GH_PAGES_TOKEN]
+ * @property {string} [inputs.GH_PAGES_BUILD_OVERRIDE]
  * @property {string} [inputs.W3C_ECHIDNA_TOKEN]
+ * @property {string} [inputs.W3C_BUILD_OVERRIDE]
  * @property {string} [inputs.W3C_WG_DECISION_URL]
  * @property {string} [inputs.W3C_NOTIFICATIONS_CC]
  *
@@ -140,10 +142,30 @@ function buildOptions(inputs) {
 		}
 	}
 
+	const configOverride = {
+		gh: getConfigOverride(inputs.GH_PAGES_BUILD_OVERRIDE),
+		w3c: getConfigOverride(inputs.W3C_BUILD_OVERRIDE),
+	};
+
 	const flags = [];
 	flags.push(...getFailOnFlags(toolchain, failOn));
 
-	return { toolchain, source, flags };
+	return { toolchain, source, flags, configOverride };
+}
+
+/** @param {string} confStr */
+function getConfigOverride(confStr) {
+	if (!confStr) {
+		return null;
+	}
+
+	/** @type {Record<string, string>} */
+	const config = {};
+	for (const line of confStr.trim().split("\n")) {
+		const [key, value] = line.split(":", 2).map(s => s.trim());
+		config[key] = value;
+	}
+	return config;
 }
 
 /**

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -6,6 +6,12 @@ async function build(outputs = {}) {
 	const toolchain = build.toolchain || "respec";
 	const source = build.source || "index.html";
 	const flags = build.flags || ["-e"];
+	const configOverride = build.configOverride || { w3c: null, gh: null };
 
-	return await require("../src/build.js")(toolchain, source, flags);
+	return await require("../src/build.js")(
+		toolchain,
+		source,
+		flags,
+		configOverride,
+	);
 }

--- a/test/deploy-gh-pages.test.js
+++ b/test/deploy-gh-pages.test.js
@@ -18,7 +18,7 @@ async function deployGhPages(outputs = {}) {
 		actor: ghPages.actor || "sidvishnoi",
 	};
 
-	const build = outputs?.build?.output || {};
+	const build = outputs?.build?.gh || {};
 	const outputDir = build.dir || path.resolve(process.cwd() + ".built");
 
 	return await require("../src/deploy-gh-pages.js")(inputs, outputDir);

--- a/test/prepare.test.js
+++ b/test/prepare.test.js
@@ -6,6 +6,13 @@ async function prepare() {
 		SOURCE: "",
 		TOOLCHAIN: "respec",
 		BUILD_FAIL_ON: "fatal",
+		W3C_BUILD_OVERRIDE: [
+			"specStatus: WD",
+			"shortName: my-custom-shortname",
+			"previousMaturity: LC",
+			"previousPublishDate: 2014-05-01",
+		].join("\n"),
+		GH_PAGES_BUILD_OVERRIDE: "specStatus: ED\n",
 		VALIDATE_LINKS: "false",
 		VALIDATE_MARKUP: "",
 		GH_PAGES_BRANCH: "",

--- a/test/validate-links.test.js
+++ b/test/validate-links.test.js
@@ -7,7 +7,7 @@ async function validateLinks(outputs = {}) {
 		return;
 	}
 
-	const build = outputs?.build?.output || {};
+	const build = outputs?.build?.w3c || {};
 	const outputDir = build.dir || ".";
 
 	return await require("../src/validate-links.js")(outputDir);

--- a/test/validate-markup.test.js
+++ b/test/validate-markup.test.js
@@ -7,7 +7,7 @@ async function validateMarkup(outputs = {}) {
 		return;
 	}
 
-	const build = outputs?.build?.output || {};
+	const build = outputs?.build?.w3c || {};
 	const outputDir = build.dir || ".";
 
 	return await require("../src/validate-markup.js")(outputDir);


### PR DESCRIPTION
- Added `W3C_BUILD_OVERRIDE` and `GH_PAGES_BUILD_OVERRIDE` inputs.
- The config updated with `W3C_BUILD_OVERRIDE` will be used for w3c-deploy and validations.
- The config updated with `GH_PAGES_BUILD_OVERRIDE` will be used only in gh-pages-deploy deploy.
- If neither is provided, a single build using the default config will be used for validations, w3c-deploy and gh-pages-deploy.

