### PR TITLE
Make VALIDATE_LINKS false by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: fatal
   VALIDATE_LINKS:
     description: Validate hyperlinks
-    default: true
+    default: false
   VALIDATE_MARKUP:
     description: Validate markup
     default: true

--- a/docs/options.md
+++ b/docs/options.md
@@ -95,7 +95,7 @@ Whether or not to check for broken hyperlinks.
 
 **Possible values:** true, false
 
-**Default:** true
+**Default:** false
 
 ## `VALIDATE_MARKUP`
 


### PR DESCRIPTION
Even after the bugs with link checking get fixed, it’s better to make link checking an opt-in rather than an opt-out. So this change sets VALIDATE_LINKS to false by default.

---

In my long experience with running drafts through pubrules, there are very many times when I’ve needed to ask the W3C webmaster to OK a publication despite errors from the link checker.

The reasons include the fact that the link checker — and link-checking is general — is known to sometimes (or often) produce false positives. And other reasons. It’s complicated.

And so given that, I don’t think it’s prudent to impose link checking on spec editors by default, and force them all to opt out — because I can tell you that if we keep the default at true, I think what we’re going to end up seeing is that very many (or even most) of the spec-prod config files in our repos are all going to have VALIDATE_LINKS set to false.

Also note that while passing the link checker is a requirement for getting a document published in TR space, it’s of course not a requirement for just getting a document published via GitHub Pages.

Thus link-checking is something that editors can deal with when they first need to get a document past pubrules, and not something that every single PR author — let alone every single editor — should be forced to deal with every time they just want to submit a patch or merge something to main.

So let’s please avoid the problem of having N different editors need to all manually set VALIDATE_LINKS to false in their config files, and instead let them opt-in to link checking by setting VALIDATE_LINKS to true if they really want it.