### PR TITLE
feat(build): download remote assets before deploy

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,7 @@ runs:
       shell: bash
       env:
         FORCE_COLOR: true
+        PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 1
     - name: Prepare
       id: prepare
       run: |

--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
     "@actions/core": "^1.2.6",
     "finalhandler": "^1.1.2",
     "node-fetch": "^2.6.1",
-    "puppeteer": "^8.0.0",
+    "puppeteer": "^8",
     "serve-static": "^1.14.1",
-    "split2": "^3.2.2"
+    "split2": "^3.2.2",
+    "subresources": "^1.0.1"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json"

--- a/src/build.ts
+++ b/src/build.ts
@@ -180,6 +180,8 @@ async function findAssetsToCopy(source: Input["source"]) {
 		(url: URL) => url.origin === "https://user-images.githubusercontent.com",
 	];
 
+	process.env["PUPPETEER_EXECUTABLE_PATH"] =
+		PUPPETEER_ENV.PUPPETEER_EXECUTABLE_PATH;
 	for await (const res of getAllSubResources(rootUrl)) {
 		const url = new URL(res.url);
 		if (isLocalAsset(url)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -121,7 +121,7 @@ export class StaticServer {
 	private _server: Server;
 	private _port: number = 3000;
 
-	constructor(dir: string) {
+	constructor(dir = process.cwd()) {
 		const serve = serveStatic(dir);
 		this._server = createServer((req, res) => {
 			// @ts-expect-error
@@ -155,7 +155,7 @@ export class StaticServer {
 	}
 
 	get url() {
-		return `http://localhost:${this._port}`;
+		return new URL(`http://localhost:${this._port}`);
 	}
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -442,7 +442,7 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-puppeteer@^8.0.0:
+puppeteer@^8:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-8.0.0.tgz#a236669118aa795331c2d0ca19877159e7664705"
   integrity sha512-D0RzSWlepeWkxPPdK3xhTcefj8rjah1791GE82Pdjsri49sy11ci/JQsAO8K2NRukqvwEtcI+ImP5F4ZiMvtIQ==
@@ -538,6 +538,13 @@ string_decoder@^1.1.1:
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
+
+subresources@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/subresources/-/subresources-1.0.1.tgz#065f965a082b047929d99da441b36cdb68e9cb28"
+  integrity sha512-Hf6RqeH22tOys+XoBePUPXYYMF4zIajRzaAS0BYQBoFI1yFxvX7TJ0v7F06xPabKo2k6h1jLMDYKXnOZkWt3XA==
+  dependencies:
+    puppeteer "^8"
 
 tar-fs@^2.0.0:
   version "2.1.1"


### PR DESCRIPTION
remove `local-assets` dependency by writing application-specific logic
...which also improves performance by not running subresources twice

Closes https://github.com/w3c/spec-prod/issues/32
Currently only allows external content from https://user-images.githubusercontent.com, more URLs can be added as needed.