### PR TITLE
fix(prepare/build): support deeply nested SOURCE paths

### DIFF
--- a/src/prepare-build.ts
+++ b/src/prepare-build.ts
@@ -91,7 +91,7 @@ function getBasicBuildOptions(inputs: Inputs): BasicBuildOptions {
 		if (!parsed.base) {
 			parsed.base = "index.html";
 		} else if (!parsed.ext) {
-			parsed.dir = parsed.base;
+			parsed.dir = path.join(parsed.dir, parsed.base);
 			parsed.base = "index.html";
 		}
 		parsed.dir = path.relative(cwd, parsed.dir);


### PR DESCRIPTION
See #92.

I'm not sure how to test this. Issuing `npm run build` on my machine with the current contents of the repository reports 12 TypeScript errors. Is there something special I should be doing to set things up?