### PR TITLE
fix(validate/webidl): use crawlSpecs API

### DIFF
--- a/src/validate-webidl.ts
+++ b/src/validate-webidl.ts
@@ -14,7 +14,7 @@ if (module === require.main) {
 
 export default async function main({ dest, file }: Input) {
 	console.log(`Validating Web IDL defined in ${file}...`);
-	await install("reffy");
+	await install("reffy@4");
 	const { crawlSpecs } = require("reffy");
 
 	const fileurl = new URL(file, `file://${dest}/`).href;


### PR DESCRIPTION
The `crawl-specs` utility was moved to a different folder in latest version of Reffy and Web IDL validation currently crashes because of that.

The relevant function is now directly exported by the tool, allowing to simplify the `require` statement.