### PR TITLE
feat(build): copy linked files and their subresources

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"puppeteer": "^13",
 		"serve-static": "^1.14.2",
 		"split2": "^4.1.0",
-		"subresources": "^1.2.1"
+		"subresources": "^1.3.0"
 	},
 	"engines": {
 		"node": "^16"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -127,6 +127,23 @@ export async function sh(command: string, options: ShOptions | ShOutput = {}) {
 	}
 }
 
+export function unique<T>(items: T[], key?: (item: T) => string | number) {
+	if (!key) {
+		return [...new Set(items)];
+	}
+
+	const alreadyHas = new Set<ReturnType<typeof key>>();
+	const uniqueItems: T[] = [];
+	for (const item of items) {
+		const k = key(item);
+		if (!alreadyHas.has(k)) {
+			uniqueItems.push(item);
+			alreadyHas.add(k);
+		}
+	}
+	return uniqueItems;
+}
+
 export function yesOrNo(value: string | number | boolean): boolean | undefined {
 	const str = String(value).trim();
 	if (/^(?:y|yes|true|1|on)$/i.test(str)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -567,10 +567,10 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-subresources@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/subresources/-/subresources-1.2.1.tgz#25a6d5aa481b15e6a7965334541ba45522d8070f"
-  integrity sha512-WtIlO5qES0NZ5OTh5xdRYsF6vQs9GaioBSYNWxcGqLwtSdeknqnYP+OaOWohDFSZVdnsW74W4XyzvA0dipjWwg==
+subresources@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/subresources/-/subresources-1.3.0.tgz#9010e24fcd1708bccbe4f09105162cc10d0bd984"
+  integrity sha512-+auH8yMwjta8aEnD2XWn4ioN9Elvuf4AhbGUOhbwdKVYx4S4DPa3DY3gVsBB/X08yP9BaMvKghLeYZ2yUloGgA==
   dependencies:
     puppeteer "^13"
 


### PR DESCRIPTION
- Closes https://github.com/w3c/spec-prod/issues/131
- Closes https://github.com/w3c/spec-prod/issues/39

In the built file, finds local `a[href]`, copies them and their subresources.

Tested on [MiniApp Standardization White Paper](https://w3c.github.io/miniapp/white-paper/) and [Media Source](https://w3c.github.io/media-source/) (had to update the github.io URL to relative one).

Limitations:
- Files must be within same directory as source file (will fix this as a followup; [clreq example](https://github.com/w3c/spec-prod/issues/39#issuecomment-850957812) doesn't work as of now).
- Files must be referenced as a relative URL.