### PR TITLE
fix(build/copy-assets): prevent crash if can't fetch page

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -186,6 +186,13 @@ async function findAssetsToCopy(source: Input["source"]) {
 	for (const page of pages) {
 		const rootUrl = new URL(page);
 		console.log(`[INFO] From ${rootUrl.pathname}…`);
+		const { ok, headers } = await fetch(rootUrl);
+		if (!ok || !headers.get("content-type")?.includes("text/html")) {
+			console.log(
+				`[WARNING] Failed to fetch ${rootUrl.pathname}. Some assets might be missing.`,
+			);
+			continue;
+		}
 		for await (const res of getAllSubResources(rootUrl, { links: true })) {
 			const url = new URL(res.url);
 			if (isLocalAsset(url) && res.type === "link") {
@@ -193,10 +200,6 @@ async function findAssetsToCopy(source: Input["source"]) {
 				if (pages.has(nextPage)) continue;
 				pages.add(nextPage);
 				localAssets.push(url.pathname);
-				const { ok, headers } = await fetch(url);
-				if (ok && headers.get("content-type")?.includes("text/html")) {
-					pages.add(nextPage);
-				}
 			} else if (isLocalAsset(url)) {
 				localAssets.push(url.pathname);
 			} else if (remoteAssetRules.some(matcher => matcher(url, res.type))) {

--- a/src/build.ts
+++ b/src/build.ts
@@ -197,9 +197,10 @@ async function findAssetsToCopy(source: Input["source"]) {
 			const url = new URL(res.url);
 			if (isLocalAsset(url) && res.type === "link") {
 				const nextPage = urlToPage(url);
-				if (pages.has(nextPage)) continue;
-				pages.add(nextPage);
-				localAssets.push(url.pathname);
+				if (!pages.has(nextPage)) {
+					pages.add(nextPage);
+					localAssets.push(url.pathname);
+				}
 			} else if (isLocalAsset(url)) {
 				localAssets.push(url.pathname);
 			} else if (remoteAssetRules.some(matcher => matcher(url, res.type))) {


### PR DESCRIPTION
Fixes https://github.com/w3c/spec-prod/issues/134

Earlier, we were adding `nextPage` to root pages even when we failed to fetch it (unnoticed double call to `pages.add`). Now, we check before trying to get its subresources. Added a warning when we skip a page too.