### PR TITLE
fix(deploy/gh-pages): don't notify users with mention in commit msg

### DIFF
--- a/src/deploy-gh-pages.ts
+++ b/src/deploy-gh-pages.ts
@@ -78,7 +78,7 @@ async function commit({ sha, event, actor }: CommitInputs) {
 		commitHeadline,
 		"",
 		`SHA: ${sha}`,
-		`Reason: ${event}, by @${actor}`,
+		`Reason: ${event}, by ${actor}`,
 		"",
 		"",
 		`Co-authored-by: ${GITHUB_ACTIONS_BOT}`,


### PR DESCRIPTION
It's rather annoying behavior to notify someone about something they don't have to take any action on.