### PR TITLE
chore(deps): allow minor updates to `pnpm/action-setup`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v2.2.2
+    - uses: pnpm/action-setup@v2
       with:
         version: 7
     - uses: actions/setup-node@v3


### PR DESCRIPTION
So we can pick up their update to node 16 and avoid warnings about node 12 being deprecated.