### PR TITLE
Update to actions/upload-artifact@v3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -97,7 +97,7 @@ runs:
 
     - name: Upload Build Artifacts
       id: upload-build-artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         path: |-
           ${{ steps.build.outputs.gh && fromJson(steps.build.outputs.gh).dest }}


### PR DESCRIPTION
This removes Github warnings from client builds about node 12 and the deprecation of set-output and save-state.

The change in https://github.com/actions/upload-artifact/releases/tag/v3.0.0 was just to update to node 16.

Fixes #151.