### PR TITLE
hotfix(action.yml): don't use `.nvmrc` to workaround setup-node bug

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
         version: 7
     - uses: actions/setup-node@v3
       with:
-        node-version-file: ".nvmrc"
+        node-version: 20
     - name: Set up action
       run: |
         echo "::group::Set up action"

--- a/action.yml
+++ b/action.yml
@@ -47,12 +47,16 @@ inputs:
 runs:
   using: composite
   steps:
+    - id: action_relative_path
+      run: |
+        action_path=$(node -p 'require("path").relative(process.env.GITHUB_WORKSPACE, "${{ github.action_path }}")')
+        echo "action_path=${action_path}" >> "$GITHUB_OUTPUT"
     - uses: pnpm/action-setup@v2
       with:
-        package_json_file: ${{ github.action_path }}/package.json
+        package_json_file: ${{ steps.outputs.action_relative_path.action_path }}/package.json
     - uses: actions/setup-node@v3
       with:
-        node-version: 20
+        node-version-file: ${{ steps.outputs.action_relative_path.action_path }}/.nvmrc
     - name: Set up action
       run: |
         echo "::group::Set up action"

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,7 @@ runs:
       run: |
         action_path=$(node -p 'require("path").relative(process.env.GITHUB_WORKSPACE, "${{ github.action_path }}")')
         echo "action_path=${action_path}" >> "$GITHUB_OUTPUT"
+      shell: bash
     - uses: pnpm/action-setup@v2
       with:
         package_json_file: ${{ steps.outputs.action_relative_path.action_path }}/package.json

--- a/action.yml
+++ b/action.yml
@@ -50,10 +50,13 @@ runs:
     - id: action_relative_path
       run: |
         action_path=$(node -p 'require("path").relative(process.env.GITHUB_WORKSPACE, "${{ github.action_path }}")')
-        echo "${action_path}"
-        echo "${action_path}/package.json"
         echo "action_path=${action_path}" >> "$GITHUB_OUTPUT"
       shell: bash
+    - shell: bash
+      run: |
+        echo "${{ steps.outputs.action_relative_path.action_path }}/package.json"
+        action_path=${{ steps.outputs.action_relative_path.action_path }} node -p 'require("path").join(process.env.GITHUB_WORKSPACE, process.env.action_path)'
+  
     - uses: pnpm/action-setup@v2
       with:
         package_json_file: ${{ steps.outputs.action_relative_path.action_path }}/package.json

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
   steps:
     - uses: pnpm/action-setup@v2
       with:
-        run_install: false
+        package_json_file: ${{ github.action_path }}/package.json
     - uses: actions/setup-node@v3
       with:
         node-version: 20

--- a/action.yml
+++ b/action.yml
@@ -48,8 +48,6 @@ runs:
   using: composite
   steps:
     - uses: pnpm/action-setup@v2
-      with:
-        version: 7
     - uses: actions/setup-node@v3
       with:
         node-version: 20

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,8 @@ runs:
     - id: action_relative_path
       run: |
         action_path=$(node -p 'require("path").relative(process.env.GITHUB_WORKSPACE, "${{ github.action_path }}")')
+        echo "${action_path}"
+        echo "${action_path}/package.json"
         echo "action_path=${action_path}" >> "$GITHUB_OUTPUT"
       shell: bash
     - uses: pnpm/action-setup@v2

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,8 @@ runs:
   using: composite
   steps:
     - uses: pnpm/action-setup@v2
+      with:
+        run_install: false
     - uses: actions/setup-node@v3
       with:
         node-version: 20

--- a/action.yml
+++ b/action.yml
@@ -55,15 +55,15 @@ runs:
       shell: bash
     - shell: bash
       run: |
-        echo "${{ steps.outputs.action_relative_path.action_path }}/package.json"
-        action_path=${{ steps.outputs.action_relative_path.action_path }} node -p 'require("path").join(process.env.GITHUB_WORKSPACE, process.env.action_path)'
+        echo "${{ steps.action_relative_path.outputs.action_path }}/package.json"
+        action_path=${{ steps.action_relative_path.outputs.action_path }} node -p 'require("path").join(process.env.GITHUB_WORKSPACE, process.env.action_path)'
   
     - uses: pnpm/action-setup@v2
       with:
-        package_json_file: ${{ steps.outputs.action_relative_path.action_path }}/package.json
+        package_json_file: ${{ steps.action_relative_path.outputs.action_path }}/package.json
     - uses: actions/setup-node@v3
       with:
-        node-version-file: ${{ steps.outputs.action_relative_path.action_path }}/.nvmrc
+        node-version-file: ${{ steps.action_relative_path.outputs.action_path }}/.nvmrc
     - name: Set up action
       run: |
         echo "::group::Set up action"

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,7 @@ runs:
   steps:
     - id: action_relative_path
       run: |
+        node -p 'process.env.GITHUB_WORKSPACE'
         action_path=$(node -p 'require("path").relative(process.env.GITHUB_WORKSPACE, "${{ github.action_path }}")')
         echo "action_path=${action_path}" >> "$GITHUB_OUTPUT"
       shell: bash


### PR DESCRIPTION
Fixes https://github.com/w3c/spec-prod/issues/164
The proper fix would be https://github.com/w3c/spec-prod/pull/165 (See https://github.com/w3c/spec-prod/pull/165#issuecomment-1715474624)