### PR TITLE
Add codespell config, workflow + make it fix a typo

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -35,7 +35,7 @@ export default async function main(toolchain: "respec" | "bikeshed" | string) {
 			break;
 		}
 		default: {
-			const msg = `Envirnoment variable "INPUTS_TOOLCHAIN" must be either one of "respec" or "bikeshed". found "${toolchain}"`;
+			const msg = `Environment variable "INPUTS_TOOLCHAIN" must be either one of "respec" or "bikeshed". found "${toolchain}"`;
 			exit(msg, 1);
 		}
 	}


### PR DESCRIPTION
Just was around this repo and found it having a typo and seeing prior commits "manually" finding/fixing typos. With https://github.com/codespell-project/codespell you can prevent them getting accepted.