### PR TITLE
fix: don't break with multiple specs, add `ARTIFACT_NAME` option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
     description: Source file path.
   DESTINATION:
     description: Destination path, relative to repository root.
+  ARTIFACT_NAME:
+    description: Name for build artifact.
+    default: "spec-prod-result"
   BUILD_FAIL_ON:
     description: Exit behaviour on errors.
     default: fatal
@@ -123,7 +126,7 @@ runs:
         path: |-
           ${{ steps.build.outputs.gh && fromJson(steps.build.outputs.gh).dest }}
           ${{ steps.build.outputs.w3c && fromJson(steps.build.outputs.w3c).dest }}
-        name: spec-prod-result
+        name: ${{ inputs.ARTIFACT_NAME }}
         retention-days: 5
 
     - name: Validate hyperlinks

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
   DESTINATION:
     description: Destination path, relative to repository root.
   ARTIFACT_NAME:
-    description: Name for build artifact.
+    description: Name for build artifact. Required when building multiple documents in same job.
     default: "spec-prod-result"
   BUILD_FAIL_ON:
     description: Exit behaviour on errors.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -200,7 +200,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: w3c/spec-prod@v2
         with:
-          ARTIFACT_NAME: ${{ matrix.name }}
+          ARTIFACT_NAME: ${{ matrix.name }} # required when building multiple documents in same job
           SOURCE: ${{ matrix.source }}
           DESTINATION: ${{ matrix.destination }}
           GH_PAGES_BRANCH: gh-pages

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -184,19 +184,23 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-          - source: spec.html
+          - name: spec-0
+            source: spec.html
             destination: index.html
             echidna_token: ECHIDNA_TOKEN_SPEC
-          - source: spec-1
+          - name: spec-1
+            source: spec-1
             destination: the-spec
             echidna_token: ECHIDNA_TOKEN_SPEC1
-          - source: spec-2
+          - name: spec-2
+            source: spec-2
             # destination defaults to spec-2/index.html
             # echidna_token defaults to no publication to w3.org/TR
     steps:
       - uses: actions/checkout@v4
       - uses: w3c/spec-prod@v2
         with:
+          ARTIFACT_NAME: ${{ matrix.name }}
           SOURCE: ${{ matrix.source }}
           DESTINATION: ${{ matrix.destination }}
           GH_PAGES_BRANCH: gh-pages

--- a/docs/options.md
+++ b/docs/options.md
@@ -32,6 +32,14 @@ Location of generated HTML document and other assets. This is useful when you've
 | `my-spec-src`     | `my-spec-out` | `./my-spec-out/index.html` | `./my-spec-out/`           |
 | `index.html`      | `index.html`  | `./index.html`             | `./`                       |
 
+## `ARTIFACT_NAME`
+
+Name for artifact which will be uploaded to workflow run. Required when building multiple documents in same job.
+
+**Possible values:** Any valid artifact name.
+
+**Default:** `"spec-prod-result"`.
+
 ## `BUILD_FAIL_ON`
 
 Define exit behaviour on build errors or warnings.


### PR DESCRIPTION
In [v2.11.0](https://github.com/w3c/spec-prod/releases/tag/v2.11.0), `actions/upload-artifact` [was updated to v4](https://github.com/w3c/spec-prod/pull/173) which started to cause issues in the WebExtensions Community Group repository. In particular, v4 requires each invocation to have a unique artifact name (this was a [breaking change](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#multiple-uploads-to-the-same-named-artifact)) and that does not hold true when using spec-prod since there is no way to configure the name.

[Configuration](https://github.com/w3c/webextensions/blob/5ec00959f2f0710d2d95a71adbe891786a2c6cf7/.github/workflows/deploy.yml#L46) / [Example failure](https://github.com/w3c/webextensions/actions/runs/8703930854/job/23871146610)

To resolve this, add a new input option to allow the name to be changed. After playing around for a bit this seemed like the simplest solution that would work for everyone :)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/oliverdunk/spec-prod/pull/180.html" title="Last updated on Apr 16, 2024, 2:41 PM UTC (025bc4d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/spec-prod/180/071d7eb...oliverdunk:025bc4d.html" title="Last updated on Apr 16, 2024, 2:41 PM UTC (025bc4d)">Diff</a>