### PR TITLE
fix: don't require `ARTIFACT_NAME` with multiple specs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,9 +13,6 @@ inputs:
     description: Source file path.
   DESTINATION:
     description: Destination path, relative to repository root.
-  ARTIFACT_NAME:
-    description: Name for build artifact. Required when building multiple documents in same job.
-    default: "spec-prod-result"
   BUILD_FAIL_ON:
     description: Exit behaviour on errors.
     default: fatal
@@ -49,6 +46,8 @@ inputs:
     description: Override Bikeshed's metadata or ReSpec's respecConfig for W3C deployment and validations.
   W3C_NOTIFICATIONS_CC:
     description: Comma separated list of email addresses to CC
+  ARTIFACT_NAME:
+    description: Name for build artifact
 
 runs:
   using: composite
@@ -126,7 +125,7 @@ runs:
         path: |-
           ${{ steps.build.outputs.gh && fromJson(steps.build.outputs.gh).dest }}
           ${{ steps.build.outputs.w3c && fromJson(steps.build.outputs.w3c).dest }}
-        name: ${{ inputs.ARTIFACT_NAME }}
+        name: ${{ steps.prepare.outputs.build && fromJson(steps.prepare.outputs.build).artifactName }}
         retention-days: 5
 
     - name: Validate hyperlinks

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -184,23 +184,19 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-          - name: spec-0
-            source: spec.html
+          - source: spec.html
             destination: index.html
             echidna_token: ECHIDNA_TOKEN_SPEC
-          - name: spec-1
-            source: spec-1
+          - source: spec-1
             destination: the-spec
             echidna_token: ECHIDNA_TOKEN_SPEC1
-          - name: spec-2
-            source: spec-2
+          - source: spec-2
             # destination defaults to spec-2/index.html
             # echidna_token defaults to no publication to w3.org/TR
     steps:
       - uses: actions/checkout@v4
       - uses: w3c/spec-prod@v2
         with:
-          ARTIFACT_NAME: ${{ matrix.name }} # required when building multiple documents in same job
           SOURCE: ${{ matrix.source }}
           DESTINATION: ${{ matrix.destination }}
           GH_PAGES_BRANCH: gh-pages

--- a/docs/options.md
+++ b/docs/options.md
@@ -32,14 +32,6 @@ Location of generated HTML document and other assets. This is useful when you've
 | `my-spec-src`     | `my-spec-out` | `./my-spec-out/index.html` | `./my-spec-out/`           |
 | `index.html`      | `index.html`  | `./index.html`             | `./`                       |
 
-## `ARTIFACT_NAME`
-
-Name for artifact which will be uploaded to workflow run. Required when building multiple documents in same job.
-
-**Possible values:** Any valid artifact name.
-
-**Default:** `"spec-prod-result"`.
-
 ## `BUILD_FAIL_ON`
 
 Define exit behaviour on build errors or warnings.
@@ -192,3 +184,11 @@ A URL to the working group decision to use auto-publish, usually from a w3c mail
 Comma separated list of email addresses to CC. This field is optional.
 
 **Default:** None.
+
+## `ARTIFACT_NAME`
+
+Name for artifact which will be uploaded to workflow run. Required to be unique when building multiple documents in same job.
+
+**Possible values:** Any valid artifact name.
+
+**Default:** `"spec-prod-result"` or inferred from `SOURCE`.

--- a/src/build.ts
+++ b/src/build.ts
@@ -6,8 +6,9 @@ import { env, exit, setOutput, sh, unique } from "./utils.js";
 import { deepEqual, StaticServer } from "./utils.js";
 import { PUPPETEER_ENV } from "./constants.js";
 
-import { BasicBuildOptions } from "./prepare-build.js";
+import { BasicBuildOptions as BasicBuildOptions_ } from "./prepare-build.js";
 import { ProcessedInput } from "./prepare.js";
+type BasicBuildOptions = Omit<BasicBuildOptions_, "artifactName">;
 type Input = ProcessedInput["build"];
 type ConfigOverride = Input["configOverride"]["gh" | "w3c"];
 type BuildSuffix = "common" | "gh" | "w3c";

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -25,6 +25,7 @@ export interface Inputs {
 	W3C_BUILD_OVERRIDE: string;
 	W3C_WG_DECISION_URL: string;
 	W3C_NOTIFICATIONS_CC: string;
+	ARTIFACT_NAME?: string;
 }
 
 export interface GitHubContext {


### PR DESCRIPTION
Automatically generate artifact name based on source. Respect `ARTIFACT_NAME` set in inputs, as added in https://github.com/w3c/spec-prod/pull/180.

So that https://github.com/w3c/spec-prod/pull/173 will no longer be a breaking as mentioned [`v2.11.2`](https://github.com/w3c/spec-prod/releases/tag/v2.11.2).

The artifact name may change from `spec-prod-result` even with single spec, though some effort was made to keep it stable (i.e. if source is `index.html` or `index.bs`). The automatic name will still start with `spec-prod-result`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/spec-prod/pull/181.html" title="Last updated on Apr 17, 2024, 1:19 PM UTC (e412ddb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/spec-prod/181/5cf6473...e412ddb.html" title="Last updated on Apr 17, 2024, 1:19 PM UTC (e412ddb)">Diff</a>