### PR TITLE
fix(deploy/w3c): don't crash if file is already named `Overview.html`

### DIFF
--- a/src/deploy-w3c-echidna.ts
+++ b/src/deploy-w3c-echidna.ts
@@ -97,12 +97,12 @@ async function publish(input: Input, buildOutput: BuildResult) {
 	const { wgDecisionURL: decision, token, cc, repository } = input;
 	const annotation = `triggered by auto-publish spec-prod action on ${repository}`;
 	const tarFileName = "/tmp/echidna.tar";
-	await sh(`mv ${file} Overview.html`, { cwd: outputDir });
+	await sh(`mv -n ${file} Overview.html`, { cwd: outputDir });
 	await sh(`tar cvf ${tarFileName} *`, {
 		output: "stream",
 		cwd: outputDir,
 	});
-	await sh(`mv Overview.html ${file}`, { cwd: outputDir });
+	await sh(`mv -n Overview.html ${file}`, { cwd: outputDir });
 
 	let command = `curl '${API_URL}'`;
 	// command += ` -F "dry-run=true"`;


### PR DESCRIPTION
Fixes https://github.com/w3c/spec-prod/issues/182