### PR TITLE
fix(setup): use pipx to install Bikeshed

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -31,7 +31,7 @@ export default async function main(toolchain: "respec" | "bikeshed" | string) {
 			});
 			exportVariable("PYTHONUSERBASE", PYTHONUSERBASE);
 			await sh("bikeshed update", "stream");
-			await sh("pip3 show bikeshed | grep -i version", "buffer");
+			await sh("pipx list --short | grep -i bikeshed", "buffer");
 			break;
 		}
 		default: {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -22,7 +22,7 @@ export default async function main(toolchain: "respec" | "bikeshed" | string) {
 		}
 		case "bikeshed": {
 			await sh("pip3 --version", "buffer");
-			await sh(`pip3 install bikeshed --quiet`, {
+			await sh(`pipx install bikeshed --quiet`, {
 				output: "stream",
 				cwd: ACTION_DIR,
 				env: {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,7 +1,7 @@
-import * as path from "path";
 import { addPath, exportVariable } from "@actions/core";
-import { env, exit, install, sh } from "./utils.js";
+import * as path from "path";
 import { ACTION_DIR, PUPPETEER_ENV } from "./constants.js";
+import { env, exit, install, sh } from "./utils.js";
 
 const PYTHONUSERBASE = path.join(ACTION_DIR, "python_modules");
 
@@ -24,7 +24,6 @@ export default async function main(toolchain: "respec" | "bikeshed" | string) {
 			await sh("pip3 --version", "buffer");
 			await sh(`pipx install bikeshed --quiet`, {
 				output: "stream",
-				cwd: ACTION_DIR,
 				env: {
 					PYTHONUSERBASE,
 				},

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -21,7 +21,7 @@ export default async function main(toolchain: "respec" | "bikeshed" | string) {
 			break;
 		}
 		case "bikeshed": {
-			await sh("pip3 --version", "buffer");
+			await sh("pipx --version", "buffer");
 			await sh(`pipx install bikeshed --quiet`, {
 				output: "stream",
 				env: {


### PR DESCRIPTION
To avoid 'error: externally-managed-environment' in ubuntu-24.04. This is now the method recommended by https://speced.github.io/bikeshed/#install-normal.

Fixes #189. It's possible that we can also now remove the `cwd` and `env` parameters, but I haven't done the testing necessary to be confident of that.