### PR TITLE
fix: remove the W3C_API_KEY requirement for VALIDATE_PUBRULES

### DIFF
--- a/src/prepare-validate.ts
+++ b/src/prepare-validate.ts
@@ -1,14 +1,11 @@
-import { yesOrNo, exit } from "./utils.js";
 import { Inputs } from "./prepare.js";
+import { yesOrNo } from "./utils.js";
 
 export function validation(inputs: Inputs) {
 	const input_markup = yesOrNo(inputs.VALIDATE_INPUT_MARKUP) || false;
 	const links = yesOrNo(inputs.VALIDATE_LINKS) || false;
 	const markup = yesOrNo(inputs.VALIDATE_MARKUP) || false;
 	const pubrules = yesOrNo(inputs.VALIDATE_PUBRULES) || false;
-	if (pubrules && !inputs.W3C_API_KEY) {
-		exit("The W3C_API_KEY input is required with VALIDATE_PUBRULES");
-	}
 	const webidl = yesOrNo(inputs.VALIDATE_WEBIDL) || false;
 	return { input_markup, links, markup, pubrules, webidl };
 }

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -20,7 +20,6 @@ export interface Inputs {
 	GH_PAGES_BRANCH: string;
 	GH_PAGES_TOKEN: string;
 	GH_PAGES_BUILD_OVERRIDE: string;
-	W3C_API_KEY: string;
 	W3C_ECHIDNA_TOKEN: string;
 	W3C_BUILD_OVERRIDE: string;
 	W3C_WG_DECISION_URL: string;


### PR DESCRIPTION
The use of W3C_API_KEY was removed in #161.

Fixes #204.