### PR TITLE
chore: switch to actions/checkout@v5

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: w3c/spec-prod@v2
         with:
           SOURCE: docs/index.html

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
     name: Check linting issues
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: codespell-project/actions-codespell@v2
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
     name: Build, Validate and Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: w3c/spec-prod@v2
         with:
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ To get started, do the following:
        name: Validate and Publish to TR
        runs-on: ubuntu-latest
        steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@v5
          - uses: w3c/spec-prod@v2
            with:
              TOOLCHAIN: respec # or bikeshed

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -14,7 +14,7 @@ jobs:
     name: Build and Validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: w3c/spec-prod@v2
 ```
 
@@ -32,7 +32,7 @@ jobs:
     name: Build and Validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: w3c/spec-prod@v2
         with:
           VALIDATE_WEBIDL: false
@@ -53,7 +53,7 @@ jobs:
     name: Build and Validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: w3c/spec-prod@v2
         with:
           TOOLCHAIN: respec # or bikeshed
@@ -80,7 +80,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: w3c/spec-prod@v2
         with:
           GH_PAGES_BRANCH: gh-pages
@@ -103,7 +103,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: w3c/spec-prod@v2
         with:
           GH_PAGES_BRANCH: gh-pages
@@ -127,7 +127,7 @@ jobs:
     name: Build, Validate and Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: w3c/spec-prod@v2
         with:
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
@@ -149,7 +149,7 @@ jobs:
     name: Build, Validate and Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: w3c/spec-prod@v2
         with:
           TOOLCHAIN: respec
@@ -194,7 +194,7 @@ jobs:
             # destination defaults to spec-2/index.html
             # echidna_token defaults to no publication to w3.org/TR
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: w3c/spec-prod@v2
         with:
           SOURCE: ${{ matrix.source }}
@@ -229,7 +229,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: w3c/spec-prod@v2
         with:
           SOURCE: spec-1
@@ -254,7 +254,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: w3c/spec-prod@v2
         with:
           SOURCE: spec-2/spec.bs


### PR DESCRIPTION
Update the documentation to use [actions/checkout@v5](https://github.com/actions/checkout#checkout-v5).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/spec-prod/pull/208.html" title="Last updated on Aug 28, 2025, 8:23 AM UTC (7d93bed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/spec-prod/208/5402361...7d93bed.html" title="Last updated on Aug 28, 2025, 8:23 AM UTC (7d93bed)">Diff</a>