### PR TITLE
surface errors in the annotations

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,7 +31,8 @@ export function exit(message: string, code = 1): never {
 	if (code === 0) {
 		console.log(message);
 	} else {
-		console.log(message);
+		console.error(message);
+		core.error(message);
 	}
 	process.exit(code);
 }


### PR DESCRIPTION
When an error occurs, people are required to dig into the logs to find what went wrong, e.g. https://github.com/w3c/aria/actions/runs/18193307801
<img width="484" height="286" alt="Screenshot 2025-10-03 at 17 27 50" src="https://github.com/user-attachments/assets/36ce3dd2-4f75-48c5-b54a-83cf97db4785" />

@daniel-montalvo suggested to use the annotations to surface the errors so we don't have to check logs.
That PR makes use of the [actions toolkit](https://github.com/actions/toolkit/tree/main/packages/core#annotations) to add the annotations when there's an error.