### PR TITLE
fix: lock bikeshed to version 5

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -22,7 +22,7 @@ export default async function main(toolchain: "respec" | "bikeshed" | string) {
 		}
 		case "bikeshed": {
 			await sh("pipx --version", "buffer");
-			await sh(`pipx install bikeshed --quiet`, {
+			await sh(`pipx install 'bikeshed==5.*' --quiet`, {
 				output: "stream",
 				env: {
 					PYTHONUSERBASE,


### PR DESCRIPTION
See https://github.com/w3c/spec-prod/issues/141#issuecomment-3647593728, https://github.com/w3c/spec-prod/issues/141#issuecomment-3649415146

To prevent breakage, we'll release action with locked versions of tools.
For the next `v2.12.2` release, use the latest v5 release of bikeshed.
When upgrading to bikeshed v7, we'll release a new version of action (`2.13.0`, not `v3`), so that if specs are breaking with latest bikeshed, they can individually update their workflows to use `v2.12.2` instead of `v2` or `v2.13.0`. Instead of being forced to update, they've a choice to remain at a previous version.