### PR TITLE
chore: upgrade actions/checkout from v5 to v6

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
         id: ref
         run: |
           echo "ref=${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}" >> $GITHUB_OUTPUT
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ steps.ref.outputs.ref }}
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
     name: Check linting issues
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: codespell-project/actions-codespell@v2
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v5

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
     name: Build, Validate and Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: w3c/spec-prod@v2
         with:
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ To get started, do the following:
        name: Validate and Publish to TR
        runs-on: ubuntu-latest
        steps:
-         - uses: actions/checkout@v5
+         - uses: actions/checkout@v6
          - uses: w3c/spec-prod@v2
            with:
              TOOLCHAIN: respec # or bikeshed

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -14,7 +14,7 @@ jobs:
     name: Build and Validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: w3c/spec-prod@v2
 ```
 
@@ -32,7 +32,7 @@ jobs:
     name: Build and Validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: w3c/spec-prod@v2
         with:
           VALIDATE_WEBIDL: false
@@ -53,7 +53,7 @@ jobs:
     name: Build and Validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: w3c/spec-prod@v2
         with:
           TOOLCHAIN: respec # or bikeshed
@@ -80,7 +80,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: w3c/spec-prod@v2
         with:
           GH_PAGES_BRANCH: gh-pages
@@ -103,7 +103,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: w3c/spec-prod@v2
         with:
           GH_PAGES_BRANCH: gh-pages
@@ -127,7 +127,7 @@ jobs:
     name: Build, Validate and Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: w3c/spec-prod@v2
         with:
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
@@ -149,7 +149,7 @@ jobs:
     name: Build, Validate and Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: w3c/spec-prod@v2
         with:
           TOOLCHAIN: respec
@@ -194,7 +194,7 @@ jobs:
             # destination defaults to spec-2/index.html
             # echidna_token defaults to no publication to w3.org/TR
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: w3c/spec-prod@v2
         with:
           SOURCE: ${{ matrix.source }}
@@ -229,7 +229,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: w3c/spec-prod@v2
         with:
           SOURCE: spec-1
@@ -254,7 +254,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: w3c/spec-prod@v2
         with:
           SOURCE: spec-2/spec.bs


### PR DESCRIPTION
Checkout v6 what's new: https://github.com/actions/checkout#checkout-v6


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/anssiko/spec-prod/pull/220.html" title="Last updated on Jan 21, 2026, 5:07 PM UTC (c01b723)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/spec-prod/220/eea7372...anssiko:c01b723.html" title="Last updated on Jan 21, 2026, 5:07 PM UTC (c01b723)">Diff</a>