### PR TITLE
chore(deps): upgrade vnu from v24 to v26

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 			"reffy": "^15",
 			"respec": "^35",
 			"specberus": "^11",
-			"vnu-jar": "^24",
+			"vnu-jar": "^26",
 			"webidl2": "^24"
 		}
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   reffy: ^15
   respec: ^35
   specberus: ^11
-  vnu-jar: ^24
+  vnu-jar: ^26
   webidl2: ^24
 
 importers:


### PR DESCRIPTION
Upgrade the vnu dependency.
The [validation of the vc-use-cases spec is failing](https://github.com/w3c/vc-use-cases/issues/168) because spec-prod is running an outdated version of the the validator.