### PR TITLE
Remove Bikeshed version specifier

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -22,7 +22,7 @@ export default async function main(toolchain: "respec" | "bikeshed" | string) {
 		}
 		case "bikeshed": {
 			await sh("pipx --version", "buffer");
-			await sh(`pipx install 'bikeshed==7.*' --quiet`, {
+			await sh(`pipx install 'bikeshed' --quiet`, {
 				output: "stream",
 				env: {
 					PYTHONUSERBASE,


### PR DESCRIPTION
Per #191, letting Bikeshed try and install the latest version is good in general, and results in a much better error message when people try to run this job with a too-old Python.

Closes #191