### PR TITLE
fix(build): explicitly set up Python 3.12 to support Bikeshed v7

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -91,7 +91,7 @@ runs:
         INPUTS_GITHUB: ${{ toJSON(github) }}
 
     - name: Set up Python for Bikeshed
-      if: ${{ env.TOOLCHAIN == 'bikeshed' }}
+      if: ${{ steps.prepare.outputs.build && fromJson(steps.prepare.outputs.build).toolchain == 'bikeshed' }}
       uses: actions/setup-python@v5
       with:
         python-version: '3.12'

--- a/action.yml
+++ b/action.yml
@@ -91,6 +91,7 @@ runs:
         INPUTS_GITHUB: ${{ toJSON(github) }}
 
     - name: Set up Python for Bikeshed
+      if: ${{ env.TOOLCHAIN == 'bikeshed' }}
       uses: actions/setup-python@v5
       with:
         python-version: '3.12'

--- a/action.yml
+++ b/action.yml
@@ -90,6 +90,11 @@ runs:
         INPUTS_USER: ${{ toJSON(inputs) }}
         INPUTS_GITHUB: ${{ toJSON(github) }}
 
+    - name: Set up Python for Bikeshed
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+        
     - name: Setup toolchain
       run: |
         echo "::group::Setup toolchain"

--- a/action.yml
+++ b/action.yml
@@ -94,8 +94,8 @@ runs:
       if: ${{ steps.prepare.outputs.build && fromJson(steps.prepare.outputs.build).toolchain == 'bikeshed' }}
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
-        
+        python-version: "3.12"
+
     - name: Setup toolchain
       run: |
         echo "::group::Setup toolchain"


### PR DESCRIPTION
Bikeshed v7 introduced a strict requirement for Python 3.12+. Because the default GitHub Actions `ubuntu-latest` runner uses an older version of Python by default, `pipx install 'bikeshed==7.*'` fails with a "no matching distribution found" error.

This commit injects `actions/setup-python@v5` into the composite action directly before the toolchain setup step. This ensures `pipx` has the correct environment to install Bikeshed successfully, fixing widespread CI breakages across W3C/Explainer repositories.

Fixes #99