### PR TITLE
fix(setup/bikeshed): ensure to use `python3` with `pipx`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -96,6 +96,13 @@ runs:
       with:
         python-version: "3.12"
 
+    - name: Setup toolchain
+      run: node ${{ github.action_path }}/src/setup.ts
+      shell: bash
+      env:
+        INPUTS_TOOLCHAIN: ${{ env.TOOLCHAIN }}
+        PIPX_DEFAULT_PYTHON: python3 
+
     - name: Validate input markup
       run: |
         echo "::group::Validate input markup"

--- a/action.yml
+++ b/action.yml
@@ -96,13 +96,6 @@ runs:
       with:
         python-version: "3.12"
 
-    - name: Setup toolchain
-      run: node ${{ github.action_path }}/src/setup.ts
-      shell: bash
-      env:
-        INPUTS_TOOLCHAIN: ${{ env.TOOLCHAIN }}
-        PIPX_DEFAULT_PYTHON: python3 
-
     - name: Validate input markup
       run: |
         echo "::group::Validate input markup"
@@ -121,6 +114,7 @@ runs:
       shell: bash
       env:
         INPUTS_TOOLCHAIN: ${{ steps.prepare.outputs.build && fromJson(steps.prepare.outputs.build).toolchain }}
+        PIPX_DEFAULT_PYTHON: python3
 
     - name: Generate Static HTML
       id: build


### PR DESCRIPTION
The default `ubuntu-latest` runner uses an older Python version, causing `pipx install 'bikeshed==7.*'` to fail.