### PR TITLE
docs: clarify action does not check "main" as branch during push-deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ During a pull request, the action:
 - converts the ReSpec/Bikeshed source document to regular HTML
 - runs broken hyperlink checker, and validate markup using W3C nu validator
 
-Additionally, if a commit is pushed to the "main" branch, the action deploys the built specification to /TR/.
+Additionally, during a push, the action deploys the built specification to /TR/.
+It is therefore important to properly configure the action,
+to only consider "push" events on the `main` branch
+(or whichever branch contains the main version),
+as illustrated below.
 
 ```yml
 # .github/workflows/auto-publish.yml

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -66,6 +66,8 @@ Deployment is only done on `push` events. In this example:
 - the document is built and validated as a check in the pull request.
 - the document is built and validated, and then deployed to `gh-pages` branch, when a commit is pushed to the `main` branch.
 
+Note that `spec-prod` does not check the branch when deploying. Since deployment is often only desired from a single branch (usually `main`), it is important to filter `push` events in the `on` clause of the action.
+
 ```yaml
 # Create a file called .github/workflows/auto-publish.yml
 name: CI


### PR DESCRIPTION
This change clarifies that spec-prod *does not* check the branch before it deploys the files. This must be done in the parameters of the GitHub action.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/spec-prod/pull/236.html" title="Last updated on Jul 10, 2026, 10:15 AM UTC (b8a8ad0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/spec-prod/236/d62b400...b8a8ad0.html" title="Last updated on Jul 10, 2026, 10:15 AM UTC (b8a8ad0)">Diff</a>