### PR TITLE
fix(validate/pubrules): use Specberus v13

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 			"link-checker": "1.4.2",
 			"reffy": "^15",
 			"respec": "^37",
-			"specberus": "^12",
+			"specberus": "^13.0.1",
 			"vnu-jar": "^26",
 			"webidl2": "^24"
 		}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   link-checker: 1.4.2
   reffy: ^15
   respec: ^37
-  specberus: ^12
+  specberus: ^13.0.1
   vnu-jar: ^26
   webidl2: ^24
 

--- a/src/validate-pubrules.ts
+++ b/src/validate-pubrules.ts
@@ -30,9 +30,9 @@ interface ExtractMetadataResult {
 	};
 }
 interface SpecberusProfile {
-	config: unknown;
+	config: any;
 	name: string;
-	rules: { name: string; [key: string]: unknown }[];
+	rules: { name: string; check: (ctx: any) => void }[];
 }
 
 const require = createRequire(import.meta.url);
@@ -82,52 +82,37 @@ export default async function main({ dest, file }: Input) {
 	}
 }
 
-function sinkAsync<T>() {
-	const { Sink } = require("specberus/lib/sink");
-	const noop = () => {};
-	const sink = new Sink(noop, noop, noop, noop);
-	return {
-		sink,
-		resultPromise: new Promise<T>((res, rej) => {
-			sink.on("end-all", res);
-			sink.on("exception", rej);
-		}),
-	};
-}
-
 async function validate(url: URL) {
-	const { Specberus } = require("specberus");
+	// @ts-ignore (specberus is lazily installed)
+	const { Specberus } = await import("specberus");
 	const specberus = new Specberus();
 
 	console.log("getting metadata");
-	const { metadata } = await extractMetadata(url);
+	const {
+		metadata: { profile },
+	} = await extractMetadata(url);
 
-	const { profiles } = require("specberus/lib/util");
-	const importedProfile: SpecberusProfile = await profiles[metadata.profile];
-	const profile: SpecberusProfile = {
+	// @ts-ignore (specberus is lazily installed)
+	const { profiles } = await import("specberus/lib/util.js");
+	const importedProfile: SpecberusProfile = await profiles[profile];
+	const filteredProfile = {
 		...importedProfile,
 		rules: importedProfile.rules.filter(({ name }) => !IGNORED_RULES.has(name)),
 	};
 
-	console.log(`validating using profile: ${profile.name}`);
-	const { sink, resultPromise } = sinkAsync<Result>();
-	specberus.validate({
+	console.log(`validating using profile: ${filteredProfile.name}`);
+	const { errors, metadata, success, warnings } = await specberus.validate({
 		url: url.href,
-		profile,
-		events: sink,
-		echidnaReady: true,
+		profile: filteredProfile,
 	});
-	const result = await resultPromise;
-	delete result.info;
-	return result;
+	return { errors, metadata, success, warnings };
 }
 
 async function extractMetadata(url: URL) {
-	const { Specberus } = require("specberus");
+	// @ts-ignore (specberus is lazily installed)
+	const { Specberus } = await import("specberus");
 	const specberus = new Specberus();
 
-	const { sink, resultPromise } = sinkAsync<ExtractMetadataResult>();
-	specberus.extractMetadata({ url, events: sink });
-	const result = await resultPromise;
+	const result = await specberus.extractMetadata({ url });
 	return result;
 }


### PR DESCRIPTION
This updates the `validate-pubrules` module to work with Specberus v13.0.1 or higher. (13.0.1 includes a couple of improvements to typings informed by this migration, which make it easier.)

[Specberus v13](https://github.com/w3c/specberus/releases/tag/v13.0.0) exposes promise-based APIs which behave similarly to what `SinkAsync` was doing in this wrapper, so this upgrade effectively enables spec-prod's wrapper code to be simpler.

## Note 1: Typings

I made an effort to typecheck my changes by temporarily installing `specberus` locally. However, it seems that many dependencies are only installed on-demand by the action, so I have added `@ts-ignore` comments to avoid failing `pnpm typecheck` on a default install, with the idea being that if you `pnpm i specberus` manually and then remove those `@ts-ignore` comments, `pnpm typecheck` will still pass.

If I understand correctly, the action runs `pnpm i --prod`, so I wonder if it would be reasonable to install specberus as a devDependency for purposes of type-checking in development?

## Note 2: Testing

I'm unsure of a good way to fully test updates to this action; I was able to specifically run the function exported from `validate-pubrules.ts` through a tsx REPL with the same result before and after the update. Let me know if there is more I can do to test/verify.